### PR TITLE
Fix broken link to python docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ pip install ScenarioGUI
 Developers can clone this repository.
 
 It is a good practise to use virtual environments (venv) when working on a (new) Python project so different Python and package versions don't conflict with 
-eachother. For ScenarioGUI, Python 3.10 or higher is recommended. General information about Python virtual environments can be found [here](https://docs.
-Python.org/3.9/library/venv.html) and in [this article](https://www.freecodecamp.org/news/how-to-setup-virtual-environments-in-python/).
+eachother. For ScenarioGUI, Python 3.10 or higher is recommended. General information about Python virtual environments can be found [here](https://docs.python.org/3.9/library/venv.html) and in [this article](https://www.freecodecamp.org/news/how-to-setup-virtual-environments-in-python/).
 
 
 ### Get started with ScenarioGUI


### PR DESCRIPTION
Minor fix to the python docs link in README.md

![image](https://github.com/tblanke/ScenarioGUI/assets/17304934/71348336-01a0-438c-a7ff-94d61f1e0f10)
